### PR TITLE
Fix for Issue #1: Only select interfaces that have a broadcast address available

### DIFF
--- a/pylifx/networking.py
+++ b/pylifx/networking.py
@@ -31,8 +31,12 @@ _AVAILABLE_INTERFACES = {}
 # Only support IPv4. Broadcast isn't in IPv6.
 for intf_name in interfaces():
     addrs = ifaddresses(intf_name)
+    # Note: only supports first address with broadcast on interface.
     if addrs.has_key(AF_INET):
-        _AVAILABLE_INTERFACES[intf_name] = addrs[AF_INET][0]
+        for addr in addrs[AF_INET]:
+            if addr.has_key('broadcast'):
+                _AVAILABLE_INTERFACES[intf_name] = addr
+                break
 
 def get_interfaces():
     return _AVAILABLE_INTERFACES


### PR DESCRIPTION
This patch fixes issue #1, by only selecting available interfaces that have a broadcast address.

Before the patch, this was the output from `pylifx.networking.get_interfaces()`:

``` pycon
>>> pylifx.networking.get_interfaces()
{
 'en1': {'broadcast': '172.20.0.255', 'netmask': '255.255.255.0', 'addr': '172.20.0.30'},
 'lo0': {'peer': '127.0.0.1', 'netmask': '255.0.0.0', 'addr': '127.0.0.1'}
}
```

After this patch is applied, the loopback interface is now excluded:

``` pycon
>>> pylifx.networking.get_interfaces()
{
 'en1': {'broadcast': '172.20.0.255', 'netmask': '255.255.255.0', 'addr': '172.20.0.30'}
}
```

This will still only use the first address with a broadcast assigned to an interface, which can cause problems with some complicated network configurations.  However it is slightly better than the old method which would only use the first address assigned to an interface, regardless of whether it had a broadcast address.
