### PR TITLE
Add support for master bulb discovery

### DIFF
--- a/pylifx/interface.py
+++ b/pylifx/interface.py
@@ -192,7 +192,7 @@ class LifxController(object):
 
         """
         k = self._annotate_bulb_addr(bulb_addr)
-        logger.info('Setting colour of %s to (H:%f, S:%f, B:%f) over %d seconds', (self._name if bulb_addr is None else k['bulb_addr'], hue, saturation, brightness, fadeTime)
+        logger.info('Setting colour of %s to (H:%f, S:%f, B:%f) over %d seconds', (self._name if bulb_addr is None else k['bulb_addr'], hue, saturation, brightness, fadeTime))
         self._set_colour(hue, saturation, brightness, 0, fadeTime, **k)
 
     def set_temperature(self, kelvin, fadeTime = 1, bulb_addr=None):
@@ -205,7 +205,7 @@ class LifxController(object):
 
         """
         k = self._annotate_bulb_addr(bulb_addr)
-        logger.info('Setting colour temperature of %s to (%dK) over %d seconds', (self._name if bulb_addr is None else k['bulb_addr'], kelvin, fadeTime)
+        logger.info('Setting colour temperature of %s to (%dK) over %d seconds', (self._name if bulb_addr is None else k['bulb_addr'], kelvin, fadeTime))
         self._set_colour(0, 0, 1.0, kelvin, fadeTime, **k)
 
     def run_scene(self, gradient, bulb_addr=None):

--- a/pylifx/interface.py
+++ b/pylifx/interface.py
@@ -281,6 +281,7 @@ class LifxController(object):
         for bulb in self.bulbs:
             if bulb._label == label:
                 return bulb
+
     def bulb_by_addr(self, addr):
         addr = processMAC(addr)
         # if there's an existing bulb entry, re-use it

--- a/pylifx/interface.py
+++ b/pylifx/interface.py
@@ -25,6 +25,7 @@ import logging
 
 from .networking import LifxBulbTCPServer, LifxUDPSocket, get_interface, processMAC
 
+
 __all__ = ['LifxController', 'LifxBulbEmulator', 'LifxBulbBridge']
 
 logger = logging.getLogger(__name__)
@@ -35,9 +36,11 @@ _UDP_BROADCAST_ADDR = ('255.255.255.255', _LIFX_PORT)
 _RECV_BIND_ADDR = ('0.0.0.0', _LIFX_PORT)
 _ONE_SECOND = 10000
 
+
 def _interpolate(min_x, max_x, min_fx, max_fx, x):
     range_x = max_x - min_x
     return min_fx + (max_fx - min_fx)*(x - min_x)/range_x
+
 
 def _smooth_gradient(gradient):
     smoothed_gradient = []
@@ -55,6 +58,7 @@ def _smooth_gradient(gradient):
             smoothed_gradient.append((red, green, blue))
         smoothed_gradient.append(gradient[max_x])
     return smoothed_gradient
+
 
 class LifxBulb(object):
     """
@@ -101,6 +105,7 @@ class LifxBulb(object):
     @property
     def controller(self):
         return self._controller
+
 
 class LifxController(object):
     """
@@ -286,6 +291,7 @@ class LifxController(object):
         # label.
         return LifxBulb(self, addr)
 
+
 class LifxBulbEmulator:
     _properties = {
         'bulbLabel': '\x00' * 32,
@@ -378,6 +384,7 @@ class LifxBulbEmulator:
         with self._prop_lock:
             sock.send_as_bulb('powerState', **self._properties)
             self._udpsock.send_as_bulb('powerState', **self._properties)
+
 
 class LifxBulbBridge(LifxBulbEmulator):
     _reserved_fields = {

--- a/pylifx/packet.py
+++ b/pylifx/packet.py
@@ -469,7 +469,7 @@ def _processForRead(payload_name, payload_spec):
     return {
         'name': payload_name,
         'format': type_format,
-        'fields': fields, 
+        'fields': fields,
     }
 
 for name, values in _PAYLOADS.items():


### PR DESCRIPTION
I noticed that this library does not provide methods for automatically discovering bulbs on the network (from what I could tell at least).

`find_master_bulb` takes a broadcast address to search for master bulbs on the network. Example use would be as follows:

```
import socket
import netifaces
import pylifx.networking

addr = netifaces.interfaces()['wlan0'][socket.AF_INET][0]['broadcast']
pylifx.networking.find_master_bulb(addr)
```

Which returns:

```
{'ip': '192.168.0.38', 'site_addr': '031f7b7b64f6'}
```

I did not include automatic detection of broadcast addresses as part of the method itself as this felt like too much of a high level abstraction for a library. You can see a working example of how this code can be used in my `lifx-cmd` repository, which includes the original implementation `find_master_bulb` is based off:

https://github.com/MichaelAquilina/lifx-cmd/blob/master/bin/lifx-discover

Let me know what you think. I am open to changing anything that you feel does not follow the general guidelines of this repo.

I have several PEP8 fixes included as part of this change as my IDE automatically applies them in most cases.

NOTE: This change is currently based off the changes in  #9 as I needed a working implementation to test this. However I included the hotfix in a separate pull request as I imagine you would want to discuss this new feature in detail before merging it while you would want the hotfix merged in ASAP.
